### PR TITLE
Add decision template and preliminary documents

### DIFF
--- a/decisions/0000-template.md
+++ b/decisions/0000-template.md
@@ -1,0 +1,69 @@
+# [short title of solved problem and solution]
+
+- Status: **[Proposed | Rejected | Accepted | Deprecated | … | Superseded by [LINK]()]**
+- Deciders: [list everyone involved in the decision]
+- Date: [DD-MM-YYYY when the decision was last updated]
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers
+
+- [driver 1, e.g., a force, facing concern, sustainability issue…]
+- [driver 2, e.g., a force, facing concern, sustainability issue…]
+
+## Considered Options
+
+1. [option 1]
+2. [option 2]
+3. [option 3]
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences
+
+- [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+- …
+
+### Negative Consequences
+
+- [e.g., compromising quality attribute, follow-up decisions required, …]
+- …
+
+## Pros and Cons of the Options
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+- Good, because [argument a]
+- Good, because [argument b]
+- Bad, because [argument c]
+- … <!-- numbers of pros and cons can vary -->
+
+## Links
+
+- [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+- … <!-- numbers of links can vary -->
+

--- a/decisions/0001-c-standard.md
+++ b/decisions/0001-c-standard.md
@@ -1,0 +1,40 @@
+# C++ Standard
+
+- Status: **Accepted**
+- Deciders: Lamar Moore, Dan Nixon, Adam Washington, Tristan Youngs
+- Date: 15-06-2020
+
+## Context and Problem Statement
+
+The project to date uses little functionality of modern C++ standards, owing to its use of custom classes for list, object management etc. C++11 is required for Qt5 support. Modernisation of the project requires the use of newer C++ features than those available in C++11.
+
+## Decision Drivers
+
+- Need for modernisation - e.g. removal of custom classes in favour of STL replacements
+- Replacement of raw pointer usage with references where possible, requiring the use of `std::optional` (from C++17)
+
+## Considered Options
+
+1. Move to C++17
+2. Move to C++20
+
+## Decision Outcome
+
+Chosen option: "C++17", because it provides all features necessary for current modernisation efforts.
+
+### Positive Consequences
+
+- Ability to reduce raw pointer usage in favour of references, especially in cases where a getter may need to return no object (using `std::optional<std::reference_wrapper<T>>`)
+- Preparedness for integrating next major version of Qt (version 6) which will rely on C++17
+
+### Negative Consequences
+
+- Enforcing C++17 breaks generation of AppImages via [AppImageKit](https://github.com/AppImage/AppImageKit), which enforces building on the oldest LTS Ubuntu version (at time of writing 16.04) whose system `gcc` does not support C++17
+
+## Pros and Cons of the Options 
+
+N/A.
+
+## Links
+
+- PR [#293](https://github.com/projectdissolve/dissolve/pull/293) moves the code to C++17 use

--- a/decisions/0002-grammars.md
+++ b/decisions/0002-grammars.md
@@ -1,0 +1,49 @@
+# Grammar Generation (Parser / Lexers)
+
+- Status: **Proposed**
+- Deciders: Dan Nixon, Adam Washington, Tristan Youngs
+- Date: 25-07-2020
+
+## Context and Problem Statement
+
+Necessary grammars in Dissolve (e.g. for mathematical expression handling) are encompassed in parser/lexers generated with [Bison](https://www.gnu.org/software/bison/). Bison is stable but no longer actively developed, and is considered as a legacy code in this context.
+
+## Decision Drivers
+
+- Bison is legacy software: stable, but no longer actively maintained
+- Bison C++ support is of limited functionality, and does not permit modern routes to its incorporation into the parent code
+
+## Considered Options
+
+1. [ANTLR](https://www.antlr.org/)
+
+## Decision Outcome
+
+Chosen option: "ANTLR", because it is the only modern alternative available.
+
+### Positive Consequences
+
+- Clearer definition of grammars (use of regular expressions, token validator functions etc.)
+- No custom lexer required
+- Better C++ integration between parser and 'real' code
+
+### Negative Consequences
+
+- ANTLR4 has a separate C++ runtime library that is not widely available on all platforms (e.g. Windows, Ubuntu 18.04), requiring additional effort to ensure that the dependency is available at build time (in both user and CI spaces)
+
+## Pros and Cons of the Options
+
+### ANTLR
+
+[ANTLR](https://www.antlr.org/) (current version 4.8 at time of writing) is a modern parser generator with good C++ support.
+[ANTLR4 on GitHub](https://github.com/antlr/antlr4)
+
+- Good, because it is actively maintained and well-supported
+- Good, because its main Java component is available on all major architectures
+- Good, because it offers useful capability beyond Bison (e.g regular expressions)
+- Good, because it has superior C++ support to Bison
+- Bad, because the C++ runtime library is potentially unavailable in package repositories for some sytems
+
+## Links
+
+- PR [#312](https://github.com/projectdissolve/dissolve/pull/312) implements the NETA grammar in ANTLR4.

--- a/decisions/0003-print-formatting.md
+++ b/decisions/0003-print-formatting.md
@@ -1,0 +1,56 @@
+# Print Formatting
+
+- Status: **Accepted**
+- Deciders: Dan Nixon, Tristan Youngs
+- Date: 24-07-2020
+
+## Context and Problem Statement
+
+Extensive use of C-style `printf` and friends throughout code, which requires modernisation.
+
+## Decision Drivers
+
+- Remove use of vulnerable C string formatting functions
+- Need for more flexible print formatting (e.g. text alignment etc.)
+- Require ability to handle non-POD objects (specifically `std::string` and related classes) in printed output
+
+## Considered Options
+
+1. [tinyformat](https://github.com/c42f/tinyformat)
+2. [fmtlib](https://github.com/fmtlib/fmt)
+
+## Decision Outcome
+
+Chosen option: "fmtlib", because it provides more comprehensive formatting solution, and paves the way for C++20 standardisation.
+
+### Positive Consequences
+
+- Simplification of majority of print output calls throughout the code
+- Handling of `std::string` formatting ahead of future modernisation work (see [#286](https://github.com/projectdissolve/dissolve/issues/286))
+
+### Negative Consequences
+
+- Lack of pre-built package for Windows systems: no Chocolatey package; no `gcc` version in Conan?
+
+## Pros and Cons of the Options
+
+### tinyformat
+
+[tinyformat](https://github.com/c42f/tinyformat) is a minimal, type-safe printf() replacement.
+
+- Good, because exists as a single header file (to be included in the project)
+- Good, because provides additional formatting functions such as positional arguments
+- Bad, because limited additional functionality
+- Bad, because not forward looking to C++20 standard
+
+### fmtlib
+
+[fmtlib](https://github.com/fmtlib/fmt) is a feature-rich, type-safe replacement for printf and friends.
+
+- Good, because offers additionsl formatting features such as field alignment and positional arguments
+- Good, because it is conformant to the upcoming C++ `std::format`
+- Bad, because adds an external dependency (albeit relatively well supported cross-platform)
+
+## Links
+
+- PR [#314](https://github.com/projectdissolve/dissolve/pull/314) re-implements the `Messenger` class, and various functions in `LineParser`, to utilise `fmtlib`.


### PR DESCRIPTION
This PR adds a decision document template in the `decisions/` directory and two documents covering C++ standard and grammar upgrades.
